### PR TITLE
Modify the Contributing Guide to make more sense with yuzu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions to the yuzu Games Wiki are welcomed, as keeping all of the data up
 **Table of Contents**:
 - [Info About This Wiki](#info-about-this-wiki)
   - [Angle Brackets](#angle-brackets)
-  - [yuzu Version](#citra-version)
+  - [yuzu Version](#yuzu-version)
   - [Dates](#dates)
   - [GitHub Issues](#github-issues)
   - [Screenshots](#screenshots)
@@ -26,19 +26,19 @@ Contributions to the yuzu Games Wiki are welcomed, as keeping all of the data up
 Throughout this guide, code blocks like `<Value>` are used. This means that "Value" should be replaced by something, and the "<>" should be deleted.
 
 ### yuzu Version
-All data must be collected from the latest official yuzu nightly, downloaded from [here](https://citra-emu.org/download/).
+All data must be collected from the latest official yuzu Canary, downloaded from [here](https://yuzu-emu.org/downloads/).
 
 ### Dates
 All dates follow the format `<4-Digit Year>-<2-Digit Month>-<2-Digit Day>`. For example, June 3rd 2017 would be "2017-06-03".
 
 ### GitHub Issues
-Game issues can be found [here](https://github.com/yuzu-emu/yuzu/issues). The ID of the issue can be found at the end of the URL. For example, [SNES Virtual Console Games - Crash on Boot](https://github.com/citra-emu/citra/issues/2782)'s ID is 2782.
+Game issues can be found [here](https://github.com/yuzu-emu/yuzu/issues). The ID of the issue can be found at the end of the URL. For example, [Intermittent Eternal Freezes (softlocks) - Pokemon Let's Go](https://github.com/yuzu-emu/yuzu/issues/1935)'s ID is 1935.
 
 ### Screenshots
-The recommended application for capturing the icon, boxart, and screenshots is [ShareX](https://github.com/ShareX/ShareX). Screenshots can not be compressed, and must be in the PNG format.
+The recommended application for capturing the icon and boxart is [ShareX](https://github.com/ShareX/ShareX) while we recommend using the `Capture Screenshot` feature within yuzu itself for game screenshots. Screenshots can not be compressed, and must be in the PNG format.
 
 ### Title IDs
-Title IDs can be found near the top of a log when running a game. For example, this is what it looks like for The Legend of Zelda: Ocarina of Time, 0004000000033500: `[   0.019882] Loader <Info> core/loader/ncch.cpp:Load:340: Program ID: 0004000000033500`.
+Title IDs can be found by right clicking the game in the game list and selecting `Copy Title ID to Clipboard`. For example, Shovel Knight: Treasure Trove's Title ID is 010057D0021E8000.
 
 ### TOML
 In this repo, DAT files follow the [TOML](https://github.com/toml-lang/toml) syntax, where each line consists of the creation of a piece of data. The simplest form of this is assigning a value to a key (`<Key> = <Value>`). The data types used for these `Value`s in this wiki are:
@@ -60,11 +60,11 @@ At the root, there's a folder for each game. The names of these folders should f
 ### Metadata
 The metadata for the game is located at `/<Game Name>/game.dat`. This is required info about the game, all feilds are mandatory unless noted otherwise. The DAT values (See: [TOML](#toml)) are:
 - `title` (String): English title of the game. This doesn't have to match the wiki or folder name, so there can be spaces.
-- `description` (String): Get these from [Wikipedia](https://en.wikipedia.org/wiki/List_of_Nintendo_3DS_games). Short, 2-3 line description of the game.
+- `description` (String): Get these from [Wikipedia](https://en.wikipedia.org/wiki/List_of_Nintendo_Switch_games). Short, 2-3 line description of the game.
 - `github_issues` (Array of integers): The GitHub issue IDs for the game. See: [GitHub Issues](#github-issues).
-- `needs_system_files` (Boolean): Whether the game requests the system files or not, regardless of whether it could be played without them (See: [yuzu Version](#citra-version)).
-- `needs_shared_font` (Boolean): Whether the game requests the shared font or not, regardless of whether it could be played without them (See: [yuzu Version](#citra-version)).
-- `game_type` (String): Whether the game has a retail release, `"switch"`, is an E-Shop **exclusive**, `"eshop"`, a Virtual Console game, `"vc"`, or DSiWare, `"dsi"`. This line is optional for retail releases.
+- `needs_system_files` (Boolean): Whether the game requests the system files or not, regardless of whether it could be played without them (See: [yuzu Version](#yuzu-version)).
+- `needs_shared_font` (Boolean): Whether the game requests the shared font or not, regardless of whether it could be played without them (See: [yuzu Version](#yuzu-version)).
+- `game_type` (String): Whether the game has a retail release, `"switch"` or if it's an E-Shop **exclusive**, `"eshop"`. This line is optional for retail releases.
 - `releases` (Array of tables): Info about each release of the game. **The USA release should come first.**
   - `title` (String): Title ID of this release of the game. See: [Title IDs](#title-ids).
   - `region` (String): Region of the game. Possible values are:
@@ -79,41 +79,39 @@ The metadata for the game is located at `/<Game Name>/game.dat`. This is require
   - `release_date` (String): When the game was released in this region. See: [Dates](#dates).
   - `title` (String): Title ID of this release of the game which was used during testing. See: [Title IDs](#title-ids).
 
-An example of a game metadata file is the one for [The Legend of Zelda: Majora's Mask](https://github.com/citra-emu/citra-games-wiki/blob/master/games/legend-of-zelda-majoras-mask/game.dat):
+An example of a game metadata file is the one for [Pokemon: Let's Go, Eevee!](https://github.com/yuzu-emu/yuzu-games-wiki/blob/master/games/pokemon-lets-go-eevee/game.dat):
 ```toml
-title = "The Legend of Zelda: Majora's Mask 3D"
-description = "The Legend of Zelda: Majora's Mask 3D is an action-adventure video game co-developed by Grezzo and Nintendo for the Nintendo 3DS handheld game console. The game is an enhanced remake of The Legend of Zelda: Majora's Mask, which was originally released for the Nintendo 64 home console in 2000. The game was released worldwide in February 2015"
-github_issues = [2517]
+title = "Pokemon: Let's Go, Eevee!"
+description = "Pokemon: Let's Go, Eevee! is a role-playing video game that was developed by Game Freak and published by The Pokemon Company and Nintendo for the Nintendo Switch. The game is the first installment of the main Pokemon RPG series for the Nintendo Switch. It is a enhanced remake of the 1998 video game Pokemon Yellow."
+wiki_override = "pokemon-lets-go"
+github_issues = [1935]
 needs_system_files = false
 needs_shared_font = false
+game_type = "switch"
 
 [[ releases ]]
-title = "0004000000125500"
-region = "usa"
-release_date = "2015-02-13"
-
-[[ releases ]]
-title = "0004000000125600"
-region = "eur"
-release_date = "2015-02-13"
+title = "0100187003A36000"
+region = "all"
+release_date = "2018-11-16"
 ```
 
 ### Icon
 The icon for a game is located at `/<Game Name>/icon.png` (See: [Screenshots](#screenshots). The suggested process for getting one is:
-- Make sure the ROM for the game is in your yuzu game directory.
-- Take a screenshot of yuzu's library listing (See: [yuzu Version](#citra-version)).
+- Make sure the game is in your yuzu game directory.
+- Set the icon size to `Full Size (256x256)` in the yuzu Configuration.
+- Take a screenshot of yuzu's library listing (See: [yuzu Version](#yuzu-version)).
 - Crop out the game icon.
-- The icon should be `48x48`.
+- The icon should be `256x256`.
 
 ### Boxart
 The boxart for the game is located at `/<Game Name>/boxart.png`. The suggested process for getting retail boxart is:
-- Download a scan from [GameTDB](http://www.gametdb.com/), preferably with the `Nintendo 3DS` logo on the right.
+- Download a scan from [GameTDB](http://www.gametdb.com/), preferably with the `Nintendo Switch` logo on the right.
 - The boxart should be from the USA.
 - Downsize it to `328x300` using [PicResize](http://www.picresize.com/).
 - Compress it using [TinyPNG](https://tinypng.com/).
 
 The required process for getting eShop only boxart is:
-- Run the game in yuzu (See: [yuzu Version](#citra-version)).
+- Run the game in yuzu (See: [yuzu Version](#yuzu-version)).
 - Use 1x internal resolution.
 - Increase the window size of yuzu to fill most of your monitor.
 - Screenshot the title screen, which should only be the top screen.
@@ -121,20 +119,8 @@ The required process for getting eShop only boxart is:
 - Compress it using [TinyPNG](https://tinypng.com/).
 - Examples are [Fairune](https://github.com/citra-emu/citra-games-wiki/blob/master/games/fairune/boxart.png) and [Pokémon Picross](https://github.com/citra-emu/citra-games-wiki/blob/master/games/pokemon-picross/boxart.png)
 
-The required process for getting virtual console boxart is:
-- Run the game in yuzu (See: [yuzu Version](#citra-version)).
-- Use 1x internal resolution.
-- Increase the window size of yuzu to fill most of your monitor.
-- Screenshot the title screen, which should only be the top screen.
-- Downsize it to `328x300` using [PicResize](http://www.picresize.com/).
-- Compress it using [TinyPNG](https://tinypng.com/).
-- Examples are [Legend of Zelda](https://github.com/citra-emu/citra-games-wiki/blob/master/games/legend-of-zelda/boxart.png) and [Tetris](https://github.com/citra-emu/citra-games-wiki/blob/master/games/tetris/boxart.png)
-
 ### Game Screenshots
-The screenshots for the game are located in `/<Game Name>/screenshots/` (See: [Screenshots](#screenshots)). Screenshots **must** follow these specifications:
-  - Native resolution.
-  - Smallest window size.
-  - Black background (For the blank space left and right of the bottom screen.). To achieve this, go to the [User Directory](https://citra-emu.org/wiki/user-directory/), and from there navigate to the `config` directory. Open qt-config.ini with a text editor, and set bg_blue, bg_green, and bg_red to 0.
+The screenshots for the game are located in `/<Game Name>/screenshots/` (See: [Screenshots](#screenshots)). Screenshots **must** have a resolution of `1280x720`.
 
 Additionally, if a game has a rating of 3 or higher, **you must include at least 3 screenshots**, otherwise 1 screenshot is acceptable. The names of the screenshots don't matter.
 
@@ -147,14 +133,11 @@ The metadata for a save is located at `/<Game Name>/savefiles/<Save Name>.dat`. 
 - `title_id` (String): Title ID of the game.
 
 #### Save Data
-The save data is located at `/<Game Name>/savefiles/<Save Name>.zip` (See: [yuzu Version](#citra-version)). To make a ZIP file, the process is:
-- Make sure the ROM for the game is in your yuzu game directory.
-- Right click on the game and click `Open Save Data Location`. This should open a folder named `data`.
-- Note the folder that the `data` folder is in. This is the low Title ID. As an example, the low Title ID for The Legend of Zelda: Ocarina of Time is `00033500`.
-- The folder that the low Title ID folder is in should be named `00040000`, the high Title ID.
-- Copy the high title ID folder elsewhere.
-- Delete everything from the high title ID folder except for the low Title ID folder.
-- Compress the high title ID folder into a ZIP.
+The save data is located at `/<Game Name>/savefiles/<Save Name>.zip` (See: [yuzu Version](#yuzu-version)). To make a ZIP file, the process is:
+- Make sure the game is in your yuzu game directory.
+- Right click on the game and click `Open Save Data Location`. This should open a window prompting you to select the user.
+- After selecting the user, you will be taken to the folder in which the save data is stored.
+- Compress the files within the folder into a ZIP.
 
 ## Wiki
 The wiki contains info about specific game problems, and can be modified by anyone. They use [Markdown](https://guides.github.com/features/mastering-markdown/) formatting.
@@ -163,13 +146,19 @@ Each page's title should match the game's respective folder in the code section,
 
 The format of each page is as follows:
 - H2 header with text saying `Summary`.
-- Brief summary of how the game performs: graphically, auditorily, and frame rate (with general hardware comparison - see MK7 example). See: [yuzu Version](#citra-version).
+- Brief summary of how the game performs: graphically, auditorily, and frame rate (with general hardware comparison - see MK7 example). See: [yuzu Version](#yuzu-version).
 
-An example of a game wiki page is the one for [Mario Kart 7](https://github.com/citra-emu/citra-games-wiki/wiki/Mario-Kart-7):
+An example of a game wiki page is the one for [Pokemon: Let's Go](https://github.com/yuzu-emu/yuzu-games-wiki/wiki/pokemon-lets-go):
 ```markdown
-## Summary
-Mario Kart 7 has some problems in yuzu. Graphically, the game suffers from minor issues,
-but requires decent hardware to obtain near full speed. It suffers from minor audio issues at times,
-but this does not hinder gameplay in any way. You may experience crashes on some tracks, slow down,
-and may need to transfer save files from yuzu to your 3DS to complete certain tracks.
+Pokemon: Let's Go series currently experiences freezes called softlocks in yuzu.
+This currently makes the game unplayable, but does not have major issues aside from the softlocks.
+
+Pokemon: Let's Go goes ingame if you follow the instructions below:
+
+* Dump a save. You can also use ones from the `Savefiles` section.
+* Dump and use your NAND and keys from your console following our [quickstart guide](https://yuzu-emu.org/help/quickstart/).
+* Choose the "Single Player - Handheld - Undocked" in `Emulation > Configure... > Input`
+
+#### How to get past the controller selection screen
+* In the Input Configuration tab, and choose the "Single Player - Handheld - Undocked" profile.
 ```


### PR DESCRIPTION
I've noticed that the contributuing guide was just a simple modification of the one from Citra's games wiki. I've modified it to make more sense with yuzu along with properly linking to certain parts.